### PR TITLE
chore(license): update copyright holder name to Zero Open Source™

### DIFF
--- a/.changeset/red-buckets-travel.md
+++ b/.changeset/red-buckets-travel.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+chore(license): update copyright holder name to Zero Open Source™

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Zero
+Copyright (c) 2024 Zero Open Source™ (aka ZeroOpenSource™; “Zero”)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Updated the copyright holder name in the LICENSE file from "Zero" to "Zero Open Source™ (aka ZeroOpenSource™; “Zero”)"
- Clarified project ownership and branding for legal and attribution purposes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the copyright holder name in the MIT License.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->